### PR TITLE
fix for issue #20 regarding performance/speed and the use of the spaCy Matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,12 @@ Each of `cvalues, basic, combo_basic, weirdness` and `term_extractor` take in a 
 All functions only take the string of which you would like to extract terms from as the mandatory input (the `technical_corpus`), as well as other tweakable settings, including `general_corpus` (contrasting corpus for `weirdness` and `term_extractor`), `general_corpus_size`, `verbose` (whether to print a progress bar), `weights`, `smoothing`, `have_single_word` (whether to have a single word count as a phrase) and `threshold`. If you have not read the papers and are unfamiliar with the algorithms, I recommend just using the default settings. Again, use `help` to find the details regarding each algorithm since they are all different.
 
 ### General Corpus
-Under `path/to/site-packages/pyate/default_general_domain.csv`, there is a general CSV file of a general corpus, specifically, 3000 random sentences from Wikipedia. The source of it can be found at https://www.kaggle.com/mikeortman/wikipedia-sentences. Access it using it using the following after installing `pyate`.
+Under `path/to/site-packages/pyate/default_general_domain.en.csv`, there is a general CSV file of a general corpus, specifically, 3000 random sentences from Wikipedia. The source of it can be found at https://www.kaggle.com/mikeortman/wikipedia-sentences. Access it using it using the following after installing `pyate`.
 
 ```python3
 import pandas as pd
 from distutils.sysconfig import get_python_lib  
-df = pd.read_csv(get_python_lib() + "/pyate/default_general_domain.csv")["SECTION_TEXT"]
+df = pd.read_csv(get_python_lib() + "/pyate/default_general_domain.en.csv")["SECTION_TEXT"]
 print(df.head())
 """ (Output)
 0    '''Anarchism''' is a political philosophy that...

--- a/src/pyate/term_extraction_pipeline.py
+++ b/src/pyate/term_extraction_pipeline.py
@@ -6,11 +6,13 @@ from spacy.tokens import Doc
 
 from .combo_basic import combo_basic
 from .term_extraction import TermExtraction
+from spacy.matcher import Matcher
 
 
 class TermExtractionPipeline:
     def __init__(
         self,
+        nlp,
         func: Callable[..., pd.Series] = combo_basic,
         force: bool = True,
         *args,
@@ -20,23 +22,26 @@ class TermExtractionPipeline:
         self.args = args
         self.kwargs = kwargs
         self.__name__ = self.func.__name__
+        self.matcher = Matcher(nlp.vocab)
         Doc.set_extension(self.__name__, default=None, force=force)
-
-    def __call__(self, doc: Doc):
-        term_counter = defaultdict(int)
+        self.term_counter = None
 
         def add_to_counter(matcher, doc, i, matches) -> Doc:
             match_id, start, end = matches[i]
             candidate = str(doc[start:end])
             if TermExtraction.word_length(candidate) <= TermExtraction.MAX_WORD_LENGTH:
-                term_counter[candidate] += 1
+                self.term_counter[candidate] += 1
 
         for i, pattern in enumerate(TermExtraction.patterns):
-            TermExtraction.matcher.add("term{}".format(i), add_to_counter, pattern)
-        matches = TermExtraction.matcher(doc)
+            self.matcher.add("term{}".format(i), add_to_counter, pattern)
+
+    def __call__(self, doc: Doc):
+        self.term_counter = defaultdict(int)
+
+        matches = self.matcher(doc)
         terms = self.func(
             str(doc),
-            technical_counts=pd.Series(term_counter),
+            technical_counts=pd.Series(self.term_counter),
             *self.args,
             **self.kwargs
         )

--- a/tests/custom.py
+++ b/tests/custom.py
@@ -7,7 +7,7 @@ if __name__ == "__main__":
 
     functions = (basic, combo_basic, cvalues)
     for func in functions:
-        nlp.add_pipe(TermExtractionPipeline(func), func.__name__)
+        nlp.add_pipe(TermExtractionPipeline(nlp, func), func.__name__)
     doc = nlp(corpus)
     for func in functions:
         print(func.__name__, "\n", getattr(doc._, func.__name__), "\n")

--- a/tests/test_algs.py
+++ b/tests/test_algs.py
@@ -13,7 +13,7 @@ def test_algs():
 
 def test_pipelines():
     for func in ALGORITHMS:
-        nlp.add_pipe(TermExtractionPipeline(func))
+        nlp.add_pipe(TermExtractionPipeline(nlp, func))
     doc = nlp(CORPUS)
     for func in ALGORITHMS:
         assert "term extractor" in getattr(doc._, func.__name__).index


### PR DESCRIPTION
_This pull request stems from issue #20_ 

My actions:
- cloned my fork of pyate
- created Conda environment
- `python setup.py install`
- `pip install -r requiremenets.txt`

_Working on Windows 10_

So, I made the edits in src/pyate/term_extraction.py and created a test script inside the pyate project folder to do some testing (please read the comments to understand the rationale behind the proposed code edits):

```Python
import pandas as pd
from pyate import combo_basic
import tqdm

# I am on Windows, so I need to wrap this in a __name__ == '__main__' for the multiprocessing to work properly
if __name__ == '__main__':
    series = pd.read_csv('src/pyate/default_general_domain.en.csv')["SECTION_TEXT"]  # type: pd.Series

    # in this case, individual strings are passed into combo_basic()
    # notice that for each one of those strings the Matcher patterns are added into a brand new Matcher object
    # instead of using a Matcher object that is defined in the TermExtraction class level
    # also notice that the iterations/second in the tqdm progress bar does not diminish as time passes, since, now,
    # the Matcher object is defined anew per instance of the TermExtraction class. In the previous code implementation,
    # the same Matcher object would be shared among all documents, but more importantly, the pattern rules would be
    # added to that Matcher again and again (the same rules each time). The Matcher does not ignore rules that are
    # already added. That is why it was making is slower and slower as the document loop was progressing
    for document_str in tqdm.tqdm(series):
        top_keywords = combo_basic(document_str).sort_values(ascending=False).head(5).index.tolist()

    # alternatively, you can pass all the strings and leverage a multiprocessing Pool.
    # This works too, with the new proposed code. The previous code had the same Matcher issue. Each Matcher, per
    # process, was being fed the same rules again and again. However, on my machine, the for loop above, runs way faster
    # than the multiprocessing paradigm.
    top_keywords = combo_basic(series.tolist(), verbose=True).sort_values(ascending=False).head(5).index.tolist()

    print(top_keywords)
```

A note: using multiprocessing, there is no real difference between the code before and the code now - but I can't explain why.
