### PR TITLE
Fix for #24 on multiprocessing

### DIFF
--- a/src/pyate/term_extraction.py
+++ b/src/pyate/term_extraction.py
@@ -152,6 +152,7 @@ class TermExtraction:
                     )
                 else:
                     nonlocal term_counter
+                    # update the cumulative/overall term_counter
                     for term, frequency in counter_dict.items():
                         term_counter[term] += frequency
 

--- a/src/pyate/term_extraction.py
+++ b/src/pyate/term_extraction.py
@@ -139,28 +139,21 @@ class TermExtraction:
             if seperate:
                 term_counters = []
             else:
-                term_counter = pd.Series(dtype="int64")
+                term_counter = defaultdict(int)
             if verbose:
                 pbar = tqdm(total=len(self.corpus))
 
-            def callback(counter_list):
+            def callback(counter_dict):
                 if verbose:
                     pbar.update(1)
                 if seperate:
                     term_counters.append(
-                        (tuple(counter_list.keys()), tuple(counter_list.values()))
+                        (tuple(counter_dict.keys()), tuple(counter_dict.values()))
                     )
                 else:
                     nonlocal term_counter
-                    # print(tuple(counter_list.values()))
-                    term_counter = term_counter.add(
-                        pd.Series(
-                            index=tuple(counter_list.keys()),
-                            data=tuple(counter_list.values()),
-                            dtype=np.int64,
-                        ),
-                        fill_value=0,
-                    ).astype(np.int64)
+                    for term, frequency in counter_dict.items():
+                        term_counter[term] += frequency
 
             def error_callback(e):
                 print(e)
@@ -196,7 +189,9 @@ class TermExtraction:
             )
             return self.__term_counter
         else:
-            self.__term_counter = term_counter
+            self.__term_counter = pd.Series(index=tuple(term_counter.keys()),
+                                            data=tuple(term_counter.values()),
+                                            dtype=np.int64)
             return self.__term_counter
 
 


### PR DESCRIPTION
Fix for #24 on multiprocessing

So, regarding the `multiprocessing Pool()` I think this was not the issue. More like the fact that the `add` method of the `Series` object was being used on every `callback` of the `Pool`'s `apply_async`. So, turns out the `add` method does not scale too well and it becomes slower and slower as the old `term_counter` `Series` grows. 

I instead replaced the `Series` with a `defaultdict` data structure, which I am updating on every `callback` with values from `counter_dict` (also renamed into `counter_list` into `counter_dict` since the old name was counter-intuitive).

The old code used to take close to 6min and now it takes 1min 30sec on my machine. Have a look:

```
import pandas as pd
from pyate import combo_basic

# I am on Windows, so I need to wrap this in a __name__ == '__main__' for the multiprocessing to work properly
if __name__ == '__main__':
    series = pd.read_csv('src/pyate/default_general_domain.en.csv')["SECTION_TEXT"]  # type: pd.Series
    top_keywords = combo_basic(series.tolist(), verbose=True).sort_values(ascending=False).head(5).index.tolist()

    print(top_keywords)
```
